### PR TITLE
fix: handle responsive images with incorrect aspect ratio

### DIFF
--- a/src/atom.less
+++ b/src/atom.less
@@ -74,5 +74,6 @@
 		min-height: 100%;
 		max-height: 100%;
 		margin: auto;
+		object-fit: cover;
 	}
 }

--- a/src/atom.less
+++ b/src/atom.less
@@ -74,6 +74,9 @@
 		min-height: 100%;
 		max-height: 100%;
 		margin: auto;
+	}
+
+	&cover {
 		object-fit: cover;
 	}
 }

--- a/src/atomAmp.less
+++ b/src/atomAmp.less
@@ -163,3 +163,7 @@
 	top:  ~'calc(50% - 3.1em)';
 	left:  ~'calc(50% - 3.1em)';
 }
+
+.atm-cover img {
+	object-fit: cover;
+}

--- a/src/image/AmpImage.jsx
+++ b/src/image/AmpImage.jsx
@@ -24,6 +24,7 @@ export default class AmpImage extends React.PureComponent {
       width,
       height,
       layout,
+      cover,
       alt,
       noloading,
       className,
@@ -39,7 +40,7 @@ export default class AmpImage extends React.PureComponent {
         layout={layout}
         alt={alt}
         noloading={noloading ? '' : null}
-        class={helper.cssClasses(className)}
+        class={helper.cssClasses({ [className]: true, 'atm-cover': cover })}
         {...helper.getDataProps(this.props)}
         {...helper.getAriaProps(this.props)}
       />

--- a/src/image/HtmlImage.jsx
+++ b/src/image/HtmlImage.jsx
@@ -149,6 +149,7 @@ export default class HtmlImage extends React.PureComponent {
             className={this._helper.cssClasses({
               'atm-fill': true,
               'atm-loaded': this.state.noloading && this._visibleInViewport,
+              'atm-cover': this.props.cover,
             })}
             {...this._helper.getAriaProps(this.props)}
           />

--- a/src/image/Image.jsx
+++ b/src/image/Image.jsx
@@ -28,6 +28,7 @@ export default class Image extends React.PureComponent {
       layout: null,
       noloading: false,
       extendedPadding: 0,
+      cover: false,
     };
   }
 


### PR DESCRIPTION
Use CSS3 property `object-fit` to avoid deforming images.