### PR TITLE
BREAKING CHANGE: rename text prop to html, SanitizeUrl

### DIFF
--- a/src/UIComponentHelper.js
+++ b/src/UIComponentHelper.js
@@ -188,6 +188,22 @@ export default class UIComponentHelper {
   }
 
   /**
+   * The regular expression was taken from the Closure sanitization library.
+   *
+   * @param {string} url
+   * @returns {string}
+   */
+  sanitizeUrl(url) {
+    const SAFE_URL_PATTERN =
+      /^(?:(?:https?|mailto|data|ftp|tel|file|sms):|[^&:/?#]*(?:[/?#]|$))/gi;
+
+    url = String(url);
+    if (url.match(SAFE_URL_PATTERN)) return url;
+
+    return 'unsafe:' + url;
+  }
+
+  /**
    * Serialize object as key and value pairs for using in noscript tag.
    *
    * @param {Object<string, *>} object

--- a/src/headline/Headline.jsx
+++ b/src/headline/Headline.jsx
@@ -16,7 +16,7 @@ export default class Headline extends React.PureComponent {
     return {
       id: null,
       className: '',
-      text: null,
+      html: null,
       mode: null,
       type: 'h1',
       style: null,
@@ -26,7 +26,7 @@ export default class Headline extends React.PureComponent {
 
   render() {
     let headline = null;
-    let { type: Type, id, mode, text, className, children, style } = this.props;
+    let { type: Type, id, mode, html, className, children, style } = this.props;
     let helper = this.context.$Utils.$UIComponentHelper;
     let computedClassName = helper.cssClasses(
       {
@@ -58,7 +58,7 @@ export default class Headline extends React.PureComponent {
           {...helper.getEventProps(this.props)}
           {...helper.getDataProps(this.props)}
           {...helper.getAriaProps(this.props)}
-          dangerouslySetInnerHTML={{ __html: text }}
+          dangerouslySetInnerHTML={{ __html: html }}
         />
       );
     }

--- a/src/iframe/AmpIframe.jsx
+++ b/src/iframe/AmpIframe.jsx
@@ -33,7 +33,7 @@ export default class AmpIframe extends React.PureComponent {
       marginHeight,
     } = this.props;
     let props = {
-      src,
+      src: helper.sanitizeUrl(src),
       srcDoc,
       width,
       height,

--- a/src/iframe/HtmlIframe.jsx
+++ b/src/iframe/HtmlIframe.jsx
@@ -61,6 +61,8 @@ export default class HtmlIframe extends React.PureComponent {
   }
 
   render() {
+    const src = this._helper.sanitizeUrl(this.props.src);
+
     return (
       <div
         ref={this._rootElement}
@@ -92,7 +94,7 @@ export default class HtmlIframe extends React.PureComponent {
         ) : null}
         {this.state.visibleInViewport ? (
           <iframe
-            src={this.props.src}
+            src={src}
             name={this.props.src}
             srcDoc={this.props.srcDoc}
             width={this.props.width}
@@ -121,7 +123,7 @@ export default class HtmlIframe extends React.PureComponent {
             }}
             dangerouslySetInnerHTML={{
               __html: `<iframe
-                  src="${this.props.src}"
+                  src="${src}"
                   ${
                     this.props.srcDoc !== null
                       ? `srcdoc="${this.props.srcDoc}"`

--- a/src/image/AmpImage.jsx
+++ b/src/image/AmpImage.jsx
@@ -32,7 +32,7 @@ export default class AmpImage extends React.PureComponent {
 
     return (
       <amp-img
-        src={src}
+        src={helper.sanitizeUrl(src)}
         srcSet={srcSet}
         sizes={sizes}
         width={width}

--- a/src/image/HtmlImage.jsx
+++ b/src/image/HtmlImage.jsx
@@ -95,6 +95,8 @@ export default class HtmlImage extends React.PureComponent {
   }
 
   render() {
+    const src = this._helper.sanitizeUrl(this.props.src);
+
     return (
       <div
         ref={this._rootElement}
@@ -126,7 +128,7 @@ export default class HtmlImage extends React.PureComponent {
         ) : null}
         {this.props.placeholder ? (
           <img
-            src={this.props.placeholder}
+            src={this._helper.sanitizeUrl(this.props.placeholder)}
             alt={this.props.alt}
             className={this._helper.cssClasses({
               'atm-blur': true,
@@ -139,7 +141,7 @@ export default class HtmlImage extends React.PureComponent {
         ) : null}
         {this.state.noloading ? (
           <img
-            src={this.props.src}
+            src={src}
             srcSet={this.props.srcSet}
             sizes={this.props.sizes}
             alt={this.props.alt}
@@ -159,7 +161,7 @@ export default class HtmlImage extends React.PureComponent {
           <noscript
             dangerouslySetInnerHTML={{
               __html: `<img
-                  src="${this.props.src || ''}"
+                  src="${src || ''}"
                   srcset="${this.props.srcSet || ''}"
                   sizes="${this.props.sizes || ''}"
                   alt="${this.props.alt || ''}"
@@ -236,7 +238,7 @@ export default class HtmlImage extends React.PureComponent {
 
       image.srcset = srcSet;
     } else if (src) {
-      image.src = src;
+      image.src = this._helper.sanitizeUrl(src);
     }
 
     if (image.decode) {

--- a/src/link/Link.jsx
+++ b/src/link/Link.jsx
@@ -26,12 +26,22 @@ export default class Link extends React.PureComponent {
 
   render() {
     let helper = this.context.$Utils.$UIComponentHelper;
-    let { href, title, target, mode, className, id, children, text, style, rel } =
-      this.props;
+    let {
+      href,
+      title,
+      target,
+      mode,
+      className,
+      id,
+      children,
+      text,
+      style,
+      rel,
+    } = this.props;
 
     return (
       <a
-        href={href}
+        href={helper.sanitizeUrl(href)}
         title={title}
         target={target}
         style={style}

--- a/src/list/ListItem.jsx
+++ b/src/list/ListItem.jsx
@@ -15,7 +15,7 @@ export default class ListItem extends React.PureComponent {
 
   static get defaultProps() {
     return {
-      text: null,
+      html: null,
       mode: '',
       style: null,
       className: '',
@@ -25,7 +25,7 @@ export default class ListItem extends React.PureComponent {
 
   render() {
     let helper = this.context.$Utils.$UIComponentHelper;
-    let { mode, className, children, text, style } = this.props;
+    let { mode, className, children, html, style } = this.props;
     let listItem = null;
     let componentClassName = helper.cssClasses(
       {
@@ -52,7 +52,7 @@ export default class ListItem extends React.PureComponent {
           className={componentClassName}
           {...helper.getEventProps(this.props)}
           {...helper.getDataProps(this.props)}
-          dangerouslySetInnerHTML={{ __html: text }}
+          dangerouslySetInnerHTML={{ __html: html }}
         />
       );
     }

--- a/src/paragraph/Paragraph.jsx
+++ b/src/paragraph/Paragraph.jsx
@@ -16,7 +16,7 @@ export default class Paragraph extends React.PureComponent {
   static get defaultProps() {
     return {
       className: '',
-      text: null,
+      html: null,
       mode: '',
       style: null,
       'data-e2e': null,
@@ -25,7 +25,7 @@ export default class Paragraph extends React.PureComponent {
 
   render() {
     let helper = this.context.$Utils.$UIComponentHelper;
-    let { mode, align, className, children, text, style } = this.props;
+    let { mode, align, className, children, html, style } = this.props;
     let paragraph = null;
     let componentClassName = helper.cssClasses(
       {
@@ -55,7 +55,7 @@ export default class Paragraph extends React.PureComponent {
           {...helper.getEventProps(this.props)}
           {...helper.getDataProps(this.props)}
           {...helper.getAriaProps(this.props)}
-          dangerouslySetInnerHTML={{ __html: text }}
+          dangerouslySetInnerHTML={{ __html: html }}
         />
       );
     }

--- a/src/video/AmpVideo.jsx
+++ b/src/video/AmpVideo.jsx
@@ -33,7 +33,7 @@ export default class AmpVideo extends React.PureComponent {
 
     return (
       <amp-video
-        src={src}
+        src={helper.sanitizeUrl(src)}
         poster={poster}
         autoplay={autoplay}
         controls={controls}

--- a/src/video/HtmlVideo.jsx
+++ b/src/video/HtmlVideo.jsx
@@ -49,6 +49,8 @@ export default class HtmlVideo extends React.PureComponent {
   }
 
   render() {
+    const src = this._helper.sanitizeUrl(this.props.src);
+
     return (
       <div
         ref={this._rootElement}
@@ -80,7 +82,7 @@ export default class HtmlVideo extends React.PureComponent {
         ) : null}
         {this.state.noloading ? (
           <video
-            src={this.props.src}
+            src={src}
             poster={this.props.poster}
             autoPlay={this.props.autoplay}
             controls={this.props.controls}
@@ -102,7 +104,7 @@ export default class HtmlVideo extends React.PureComponent {
           <noscript
             dangerouslySetInnerHTML={{
               __html: `<video
-								src="${this.props.src || ''}"
+								src="${src || ''}"
 								poster="${this.props.alt || ''}"
 								controls
 								${this.props.autoplay ? 'autoPlay' : ''}
@@ -178,7 +180,7 @@ export default class HtmlVideo extends React.PureComponent {
     let image = new Image();
     image.onload = onLoadingCompleted;
     image.onerror = onLoadingCompleted;
-    image.src = this.props.poster;
+    image.src = this._helper.sanitizeUrl(this.props.poster);
 
     function onLoadingCompleted() {
       if (componentInstance._mounted) {


### PR DESCRIPTION
Property text was renamed to html - it is inserting throught dangerouslySetInnerHTML
Src and href are sanitized by SanitizeUrl helper function inspired by angular https://github.com/angular/angular/blob/main/packages/core/src/sanitization/url_sanitizer.ts